### PR TITLE
adjust the padding to make the bottom line align to right icon

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -524,7 +524,7 @@
 
 				ul.alt li:first-child {
 					border-top: 0;
-					padding-top: 0;
+					padding-top: 0.29em;
 				}
 
 		ul.icons {


### PR DESCRIPTION
When I use the theme, I find the bottom line is not align to right social icons.
